### PR TITLE
Use <button type=button>  to avoid triggering form submissions

### DIFF
--- a/src/components/MeetingSelector/VueMeetingSelector.vue
+++ b/src/components/MeetingSelector/VueMeetingSelector.vue
@@ -11,6 +11,7 @@
           name="button-previous" />
         <button
           v-else
+          type="button"
           :disabled="options.disabledDate(date) || loading"
           class="tab__pagination__button"
           :class="cssClass.tabPaginationPreviousButton"
@@ -76,6 +77,7 @@
           name="button-next" />
         <button
           v-else
+          type="button"
           class="tab__pagination__button tab__pagination__button--right"
           :disabled="loading"
           :class="cssClass.tabPaginationNextButton"
@@ -88,6 +90,7 @@
           :is-disabled="skip === 0 || loading" />
         <button
           v-else
+          type="button"
           :class="cssClass.tabPaginationUpButton"
           :disabled="skip === 0 || loading"
           @click="previousMeetings"
@@ -100,6 +103,7 @@
           :is-disabled="(skip + options.limit >= maxNbMeetings) || loading" />
         <button
           v-else
+          type="button"
           :class="cssClass.tabPaginationDownButton"
           :disabled="(skip + options.limit >= maxNbMeetings) || loading"
           @click="nextMeetings"


### PR DESCRIPTION
See https://stackoverflow.com/a/3315016/701444 for some reference.

But basically while inside a `form` when using a `button` element without a type it will default to  `<button type=submit>` this will cause the parent form to submit, while this could be handled on the form, there shouldn't be a need for extra code circumvent this.

Adding the `type` attribute to the buttons avoids this issue and doesn't mess with current functionality